### PR TITLE
Add error handling to gh CLI calls in deliver_result/deliver_error

### DIFF
--- a/src/matrix_agent/channels.py
+++ b/src/matrix_agent/channels.py
@@ -72,19 +72,36 @@ class GitHubChannel(ChannelAdapter):
     async def deliver_result(self, task_id: str, text: str) -> None:
         issue_number = task_id.split("-", 1)[1]
         body = f"✅ Completed — {text}"
-        await asyncio.create_subprocess_exec(
+        proc = await asyncio.create_subprocess_exec(
             "gh", "issue", "comment", issue_number, "--body", body,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-        await asyncio.create_subprocess_exec(
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            log.error("gh issue comment failed for #%s: %s", issue_number, stderr.decode())
+            return
+
+        proc = await asyncio.create_subprocess_exec(
             "gh", "issue", "close", issue_number,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            log.error("gh issue close failed for #%s: %s", issue_number, stderr.decode())
 
     async def deliver_error(self, task_id: str, error: str) -> None:
         issue_number = task_id.split("-", 1)[1]
         body = f"❌ Failed: {error}"
-        await asyncio.create_subprocess_exec(
+        proc = await asyncio.create_subprocess_exec(
             "gh", "issue", "comment", issue_number, "--body", body,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            log.error("gh issue comment (error) failed for #%s: %s", issue_number, stderr.decode())
 
     async def is_valid(self, task_id: str) -> bool:
         """Check if the issue is still open with the agent-task label."""
@@ -133,11 +150,16 @@ class GitHubChannel(ChannelAdapter):
             results.append((task_id, message))
 
             # Post recovery comment
-            await asyncio.create_subprocess_exec(
+            proc = await asyncio.create_subprocess_exec(
                 "gh", "issue", "comment", str(number),
                 "--repo", repo,
                 "--body", "🤖 Bot restarted — resuming work on this issue.",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
+            stdout, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                log.error("gh issue comment (recovery) failed for #%s: %s", number, stderr.decode())
 
         log.info("GitHub recovery: found %d open agent-task issues", len(results))
         return results
@@ -173,10 +195,15 @@ class GitHubChannel(ChannelAdapter):
                 return web.Response(text="already processing")
 
             # Post "Working" comment
-            await asyncio.create_subprocess_exec(
+            proc = await asyncio.create_subprocess_exec(
                 "gh", "issue", "comment", str(issue["number"]),
                 "--body", "🤖 Working on this issue...",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
+            stdout, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                log.error("gh issue comment (working) failed for #%s: %s", issue["number"], stderr.decode())
 
             # Enqueue title+body as first message
             repo_full_name = payload.get("repository", {}).get("full_name", "")


### PR DESCRIPTION
Added error handling to fire-and-forget gh CLI calls in channels.py. Previously, `deliver_result`, `deliver_error`, and some webhook handlers called gh commands without checking return codes, so failures were silent.

Changes:
- `deliver_result`: Now captures stderr and logs errors for both `gh issue comment` and `gh issue close` commands
- `deliver_error`: Now captures stderr and logs errors for `gh issue comment`
- `recover_tasks`: Now captures stderr and logs errors for recovery comment
- `_handle_webhook`: Now captures stderr and logs errors for "Working" comment

The error handling follows the same pattern already used in `is_valid` - capturing stderr via `asyncio.subprocess.PIPE`, calling `.communicate()`, and checking `proc.returncode != 0`.

Closes #issue