### PR TITLE
Update default coding_timeout_seconds to 2400

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,6 @@ GITHUB_WEBHOOK_SECRET =       # shared secret for HMAC signature verification
 PODMAN_PATH = podman
 SANDBOX_IMAGE = matrix-agent-sandbox:latest
 COMMAND_TIMEOUT_SECONDS = 120
-CODING_TIMEOUT_SECONDS = 1800
+CODING_TIMEOUT_SECONDS = 2400
 MAX_AGENT_TURNS = 25
 IPC_BASE_DIR = /tmp/sandbox-ipc

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ then restart itself.
 | `PODMAN_PATH`             | `podman`                               | Path to podman binary                      |
 | `SANDBOX_IMAGE`           | `matrix-agent-sandbox:latest`          | Sandbox image name                         |
 | `COMMAND_TIMEOUT_SECONDS` | `120`                                  | Max time per shell command                 |
-| `CODING_TIMEOUT_SECONDS`  | `1800`                                 | Max time per Gemini CLI invocation         |
+| `CODING_TIMEOUT_SECONDS`  | `2400`                                 | Max time per Gemini CLI invocation         |
 | `MAX_AGENT_TURNS`         | `25`                                   | Max LLM tool-call rounds per message       |
 | `IPC_BASE_DIR`            | `/tmp/sandbox-ipc`                     | Host directory for sandbox IPC files       |
 

--- a/src/matrix_agent/config.py
+++ b/src/matrix_agent/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     podman_path: str = "podman"
     sandbox_image: str = "matrix-agent-sandbox:latest"
     command_timeout_seconds: int = 120
-    coding_timeout_seconds: int = 1800
+    coding_timeout_seconds: int = 2400
     max_agent_turns: int = 30
     screenshot_script: str = "/opt/playwright/screenshot.js"
     gemini_api_key: str = ""


### PR DESCRIPTION
Closes #12

This PR updates the default `coding_timeout_seconds` from 1800 (30 minutes) to 2400 (40 minutes) in `src/matrix_agent/config.py`, `.env.example`, and `README.md`.

Closes #issue_number