### PR TITLE
Add optional custom command parameter to run_tests tool

### DIFF
--- a/src/matrix_agent/decider.py
+++ b/src/matrix_agent/decider.py
@@ -21,7 +21,7 @@ You are a coding assistant running inside a sandboxed container. You have three 
 You also have:
 - run_command — run shell commands in the sandbox
 - read_file / write_file — read and write files in the sandbox
-- run_tests — run lint (ruff) and tests (pytest)
+- run_tests(path, command) — run lint (ruff) and tests (pytest). Use 'command' to run specific tests.
 - take_screenshot — take a browser screenshot of a URL in the sandbox
 - self_update — update the bot itself on the VPS host
 
@@ -50,11 +50,10 @@ Never use run_command to try to update the bot or restart the service — that r
 When modifying the bot's own code:
 1. run_command: git clone https://github.com/BoomMccloud/matrix-tui /workspace/matrix-tui
 2. plan/implement/review: work on /workspace/matrix-tui
-3. run_command: cd /workspace/matrix-tui && git checkout -b <branch> && git add -A && git commit -m "..."
-4. run_command: cd /workspace/matrix-tui && git push origin <branch>
-5. run_command: cd /workspace/matrix-tui && gh pr create --title "..." --body "..."
-6. Tell the user the PR URL and wait for them to review/merge
-7. After merge: self_update() to pull and restart
+3. run_tests(): verify changes pass lint and tests
+4. create_pull_request(title, body): the tool handles branching, committing, pushing, and opening the PR
+5. Tell the user the PR URL and wait for them to review/merge
+6. After merge: self_update() to pull and restart
 To test a branch before merging: self_update(branch="<branch>")
 
 Explain what you're doing as you work.\
@@ -67,7 +66,7 @@ Workflow:
 1. Clone: run_command("git clone https://github.com/<repo> /workspace/<name>")
 2. plan() — understand the codebase and design the approach. Dependencies are auto-installed and baseline tests are auto-run on first Gemini session (results in /workspace/.baseline-tests.txt).
 3. implement() — write the code
-4. run_tests() — verify lint and tests pass
+4. run_tests(path, command) — verify lint and tests pass. Use 'command' to run specific tests.
 5. review() — check for bugs and edge cases
 6. If review finds issues, implement() again
 

--- a/src/matrix_agent/tools.py
+++ b/src/matrix_agent/tools.py
@@ -144,6 +144,10 @@ TOOL_SCHEMAS = [
                         "type": "string",
                         "description": "Directory to run tests in. Defaults to /workspace.",
                     },
+                    "command": {
+                        "type": "string",
+                        "description": "Optional custom test command to run (e.g. 'pytest tests/test_foo.py'). If provided, it replaces the default pytest command.",
+                    },
                 },
             },
         },
@@ -218,9 +222,7 @@ async def execute_tool(
 
     if name == "run_command":
         cmd = args["command"]
-        # Only allow "git push --force" (for CI fix flow on feature branches).
-        # All other pushes must go through create_pull_request tool.
-        if re.search(r"\bgit\s+push\b", cmd) and not re.search(r"--force", cmd):
+        if _is_git_push_blocked(cmd):
             return "Error: git push is not allowed. Use the create_pull_request tool to submit changes.", None
         rc, stdout, stderr = await sandbox.exec(chat_id, cmd)
         output = stdout
@@ -261,10 +263,26 @@ async def execute_tool(
 
     if name == "run_tests":
         path = args.get("path", "/workspace")
-        lint_rc, lint_out, lint_err = await sandbox.exec(chat_id, f"cd {path} && ruff check .")
-        test_rc, test_out, test_err = await sandbox.exec(chat_id, f"cd {path} && pytest -v 2>&1 || true")
-        lint_result = lint_out or lint_err or "No issues."
-        test_result = test_out or test_err or "No output."
+        cmd = args.get("command", "pytest -v")
+        if _is_git_push_blocked(cmd):
+            return "Error: git push is not allowed. Use the create_pull_request tool to submit changes.", None
+        
+        path_q = _shell_quote(path)
+        lint_rc, lint_out, lint_err = await sandbox.exec(chat_id, f"cd {path_q} && ruff check .")
+        test_rc, test_out, test_err = await sandbox.exec(chat_id, f"cd {path_q} && {cmd}")
+        
+        lint_result = lint_out
+        if lint_err:
+            lint_result += f"\nSTDERR:\n{lint_err}"
+        if not lint_result.strip():
+            lint_result = "No issues."
+
+        test_result = test_out
+        if test_err:
+            test_result += f"\nSTDERR:\n{test_err}"
+        if not test_result.strip():
+            test_result = "No output."
+
         status = "PASS" if lint_rc == 0 and test_rc == 0 else "FAIL"
         output = f"[{status}]\n\n=== Lint (ruff) ===\n{lint_result}\n\n=== Tests (pytest) ===\n{test_result}"
         if len(output) > 10000:
@@ -288,6 +306,14 @@ async def execute_tool(
         return result, None
 
     return f"Unknown tool: {name}", None
+
+
+def _is_git_push_blocked(cmd: str) -> bool:
+    """True if cmd contains 'git push' without '--force' or '--force-with-lease'."""
+    if re.search(r"\bgit\s+push\b", cmd):
+        if not (re.search(r"--force", cmd) or re.search(r"--force-with-lease", cmd)):
+            return True
+    return False
 
 
 async def _create_pull_request(sandbox, chat_id, title, body):

--- a/tests/test_tools_unit.py
+++ b/tests/test_tools_unit.py
@@ -287,6 +287,77 @@ class TestExecuteTool:
         assert len(result) == 10000 + len("\n... (truncated)")
         assert result.endswith("\n... (truncated)")
 
+    async def test_run_tests_custom_command(self):
+        """run_tests: verify it uses the custom command when provided."""
+        sandbox = self._make_sandbox()
+        sandbox.exec.side_effect = [
+            (0, "No issues.", ""),  # ruff
+            (0, "custom output", ""), # custom command
+        ]
+
+        result, image = await execute_tool(
+            sandbox, "chat-1", "run_tests", '{"command": "pytest tests/test_foo.py"}'
+        )
+
+        assert sandbox.exec.call_count == 2
+        calls = [c[0][1] for c in sandbox.exec.call_args_list]
+        assert "pytest tests/test_foo.py" in calls[1]
+        assert "custom output" in result
+
+    async def test_run_tests_custom_command_failure(self):
+        """run_tests: FAIL status when custom command fails."""
+        sandbox = self._make_sandbox()
+        sandbox.exec.side_effect = [
+            (0, "No issues.", ""),  # ruff passes
+            (1, "custom test failed", "stderr message"),  # custom command fails
+        ]
+
+        result, image = await execute_tool(
+            sandbox, "chat-1", "run_tests", '{"command": "pytest tests/test_foo.py"}'
+        )
+
+        assert sandbox.exec.call_count == 2
+        calls = [c[0][1] for c in sandbox.exec.call_args_list]
+        assert "pytest tests/test_foo.py" in calls[1]
+        assert "[FAIL]" in result
+        assert "custom test failed" in result
+        assert "STDERR:" in result
+        assert "stderr message" in result
+
+    async def test_run_tests_path_quoting(self):
+        """run_tests: path is shell-quoted."""
+        sandbox = self._make_sandbox()
+        sandbox.exec.return_value = (0, "ok", "")
+
+        await execute_tool(sandbox, "chat-1", "run_tests", '{"path": "/path with spaces"}')
+
+        calls = [c[0][1] for c in sandbox.exec.call_args_list]
+        assert "cd '/path with spaces'" in calls[0]
+        assert "cd '/path with spaces'" in calls[1]
+
+    async def test_run_tests_blocks_git_push(self):
+        """run_tests: blocks git push without --force."""
+        sandbox = self._make_sandbox()
+
+        result, image = await execute_tool(
+            sandbox, "chat-1", "run_tests", '{"command": "git push origin main"}'
+        )
+
+        assert "Error: git push is not allowed" in result
+        sandbox.exec.assert_not_called()
+
+    async def test_run_tests_allows_git_push_force(self):
+        """run_tests: allows git push --force."""
+        sandbox = self._make_sandbox()
+        sandbox.exec.return_value = (0, "pushed", "")
+
+        result, image = await execute_tool(
+            sandbox, "chat-1", "run_tests", '{"command": "git push --force origin feat"}'
+        )
+
+        assert sandbox.exec.call_count == 2
+        assert "pushed" in result
+
     async def test_run_tests_output_truncation(self):
         """run_tests: output > 10000 chars is truncated."""
         sandbox = self._make_sandbox()


### PR DESCRIPTION
Closes #19

This PR adds an optional `command` parameter to the `run_tests` tool, allowing custom test commands (like `pytest --timeout=30` or running specific test files) instead of the hardcoded default.

### Key Changes:
- **Tool Schema & Implementation**: Updated `run_tests` in `src/matrix_agent/tools.py` to accept a `command` parameter.
- **Enhanced Security**: Refactored the `git push` blocking logic into a helper and applied it to `run_tests` to prevent bypassing PR policies.
- **Robustness**: Added shell quoting for the `path` parameter in `run_tests` to handle special characters safely.
- **Diagnostics**: Improved output to include `STDERR` for both linting and tests.
- **System Prompts**: Updated `SYSTEM_PROMPT` and `GITHUB_SYSTEM_PROMPT` in `src/matrix_agent/decider.py` to document the new parameter and align with tool-level policies.
- **Unit Tests**: Added comprehensive unit tests in `tests/test_tools_unit.py` covering custom commands, success/failure paths, security blocks, and path quoting.

Closes # [issue number if applicable]