### PR TITLE
Add unit tests for TaskRunner lifecycle methods (pre_register, reconcile, destroy_orphans)

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,11 +116,38 @@ async def test_pre_register_idempotent():
 
     await runner.pre_register("task-pr2", channel)
     original_queue = runner._queues["task-pr2"]
+    original_worker = runner._workers["task-pr2"]
 
     await runner.pre_register("task-pr2", channel)
     assert runner._queues["task-pr2"] is original_queue  # same object
+    assert runner._workers["task-pr2"] is original_worker  # same object
 
     await runner._cleanup("task-pr2")
+
+
+@pytest.mark.asyncio
+async def test_reconcile_preserves_valid_tasks():
+    """reconcile() does not clean up tasks when is_valid returns True."""
+    sandbox = _make_sandbox()
+    decider = _make_decider([])
+    runner = TaskRunner(decider, sandbox)
+    channel = MockChannel()
+
+    await runner.enqueue("task-valid", "hello", channel)
+    
+    # Ensure it's tracked
+    assert "task-valid" in runner._processing
+
+    # Default MockChannel returns True for is_valid
+    await runner.reconcile()
+
+    assert "task-valid" in runner._queues
+    assert "task-valid" in runner._channels
+    assert "task-valid" in runner._processing
+    assert "task-valid" in runner._workers
+    sandbox.destroy.assert_not_called()
+
+    await runner._cleanup("task-valid")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add unit tests for TaskRunner lifecycle methods (pre_register, reconcile, destroy_orphans) in src/matrix_agent/core.py.

Test cases for pre_register():
- Creates queue, worker, and adds task_id to _processing without enqueuing a message
- Calling pre_register twice with the same task_id is idempotent (no duplicate workers)

Test cases for reconcile():
- When channel.is_valid() returns False, the task is cleaned up (worker cancelled, container destroyed)
- When channel.is_valid() returns True, the task is preserved

Test cases for destroy_orphans():
- Containers in sandbox.container_ids() that are NOT in _processing are destroyed
- Containers that ARE in _processing are preserved

Modified tests/test_core.py, did not touch source code.