### PR TITLE
feat: close GitHub issue on deliver_error (v3)

### DIFF
--- a/src/matrix_agent/channels.py
+++ b/src/matrix_agent/channels.py
@@ -107,6 +107,17 @@ class GitHubChannel(ChannelAdapter):
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
             log.error("gh issue comment (error) failed for #%s: %s", issue_number, stderr.decode())
+            return
+
+        # Close the issue on failure so it's not retried on restart
+        proc = await asyncio.create_subprocess_exec(
+            "gh", "issue", "close", issue_number,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            log.error("gh issue close failed for #%s: %s", issue_number, stderr.decode())
 
     async def is_valid(self, task_id: str) -> bool:
         """Check if the issue is still open with the agent-task label."""

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -315,7 +315,7 @@ async def test_webhook_ignores_bot_comment_by_prefix(client, github_channel):
 
 @pytest.mark.asyncio
 async def test_deliver_error(github_channel):
-    """deliver_error posts a comment with the error message."""
+    """deliver_error posts a comment with the error message AND closes the issue."""
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"", b""))
@@ -325,7 +325,9 @@ async def test_deliver_error(github_channel):
     ) as mock_exec:
         await github_channel.deliver_error("gh-123", "Internal error")
 
-    mock_exec.assert_called_once_with(
+    assert mock_exec.call_count == 2
+    # First call: comment
+    mock_exec.assert_any_call(
         "gh",
         "issue",
         "comment",
@@ -335,6 +337,8 @@ async def test_deliver_error(github_channel):
         stdout=-1,
         stderr=-1,
     )
+    # Second call: close
+    mock_exec.assert_any_call("gh", "issue", "close", "123", stdout=-1, stderr=-1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR ensures that GitHub issues are closed when an error occurs during processing, preventing indefinite retries on bot restart. Fixes #64.