### PR TITLE
Add --repo flag to all gh CLI calls in GitHubChannel

### DIFF
--- a/src/matrix_agent/channels.py
+++ b/src/matrix_agent/channels.py
@@ -76,7 +76,9 @@ class GitHubChannel(ChannelAdapter):
             body = f"✅ Completed — {text}"
 
         proc = await asyncio.create_subprocess_exec(
-            "gh", "issue", "comment", issue_number, "--body", body,
+            "gh", "issue", "comment", issue_number,
+            "--repo", self.settings.github_repo,
+            "--body", body,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -89,6 +91,7 @@ class GitHubChannel(ChannelAdapter):
         if status != "max_turns":
             proc = await asyncio.create_subprocess_exec(
                 "gh", "issue", "close", issue_number,
+                "--repo", self.settings.github_repo,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -100,7 +103,9 @@ class GitHubChannel(ChannelAdapter):
         issue_number = task_id.split("-", 1)[1]
         body = f"❌ Failed: {error}"
         proc = await asyncio.create_subprocess_exec(
-            "gh", "issue", "comment", issue_number, "--body", body,
+            "gh", "issue", "comment", issue_number,
+            "--repo", self.settings.github_repo,
+            "--body", body,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -112,6 +117,7 @@ class GitHubChannel(ChannelAdapter):
         # Close the issue on failure so it's not retried on restart
         proc = await asyncio.create_subprocess_exec(
             "gh", "issue", "close", issue_number,
+            "--repo", self.settings.github_repo,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -123,7 +129,9 @@ class GitHubChannel(ChannelAdapter):
         """Check if the issue is still open with the agent-task label."""
         issue_number = task_id.split("-", 1)[1]
         proc = await asyncio.create_subprocess_exec(
-            "gh", "issue", "view", issue_number, "--json", "state,labels",
+            "gh", "issue", "view", issue_number,
+            "--repo", self.settings.github_repo,
+            "--json", "state,labels",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -220,6 +228,7 @@ class GitHubChannel(ChannelAdapter):
             # Post "Working" comment
             proc = await asyncio.create_subprocess_exec(
                 "gh", "issue", "comment", str(issue["number"]),
+                "--repo", self.settings.github_repo,
                 "--body", "🤖 Working on this issue...",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -288,6 +297,7 @@ class GitHubChannel(ChannelAdapter):
             if task_id not in self.task_runner._processing:
                 proc = await asyncio.create_subprocess_exec(
                     "gh", "issue", "comment", str(issue["number"]),
+                    "--repo", self.settings.github_repo,
                     "--body", "🤖 Working on this issue...",
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -109,7 +109,7 @@ async def test_webhook_valid_issue_labeled(client, github_channel):
 
     with patch(
         "matrix_agent.channels.asyncio.create_subprocess_exec", return_value=mock_proc
-    ):
+    ) as mock_exec:
         resp = await _post(client, _labeled_payload())
 
     assert resp.status == 202
@@ -117,6 +117,15 @@ async def test_webhook_valid_issue_labeled(client, github_channel):
     call_args = github_channel.task_runner.enqueue.call_args
     assert call_args[0][0] == "gh-7"  # task_id
     assert "Fix login bug" in call_args[0][1]  # message
+
+    # Verify gh issue comment call includes --repo
+    mock_exec.assert_any_call(
+        "gh", "issue", "comment", "7",
+        "--repo", "owner/repo",
+        "--body", "🤖 Working on this issue...",
+        stdout=-1,
+        stderr=-1,
+    )
 
 
 @pytest.mark.asyncio
@@ -332,13 +341,20 @@ async def test_deliver_error(github_channel):
         "issue",
         "comment",
         "123",
+        "--repo",
+        "owner/repo",
         "--body",
         "❌ Failed: Internal error",
         stdout=-1,
         stderr=-1,
     )
     # Second call: close
-    mock_exec.assert_any_call("gh", "issue", "close", "123", stdout=-1, stderr=-1)
+    mock_exec.assert_any_call(
+        "gh", "issue", "close", "123",
+        "--repo", "owner/repo",
+        stdout=-1,
+        stderr=-1
+    )
 
 
 @pytest.mark.asyncio
@@ -361,6 +377,8 @@ async def test_deliver_result_max_turns(github_channel):
         "issue",
         "comment",
         "123",
+        "--repo",
+        "owner/repo",
         "--body",
         "🤖 Hit turn limit",
         stdout=-1,
@@ -387,13 +405,20 @@ async def test_deliver_result_completed(github_channel):
         "issue",
         "comment",
         "123",
+        "--repo",
+        "owner/repo",
         "--body",
         "✅ Completed — Fixed everything",
         stdout=-1,
         stderr=-1,
     )
     # Second call: close
-    mock_exec.assert_any_call("gh", "issue", "close", "123", stdout=-1, stderr=-1)
+    mock_exec.assert_any_call(
+        "gh", "issue", "close", "123",
+        "--repo", "owner/repo",
+        stdout=-1,
+        stderr=-1
+    )
 
 
 @pytest.mark.asyncio
@@ -528,7 +553,9 @@ async def test_github_channel_is_valid_open_with_label(github_channel):
 
     assert valid is True
     mock_exec.assert_called_once_with(
-        "gh", "issue", "view", "123", "--json", "state,labels",
+        "gh", "issue", "view", "123",
+        "--repo", "owner/repo",
+        "--json", "state,labels",
         stdout=-1, stderr=-1
     )
 

--- a/tests/test_channels_ci_fix.py
+++ b/tests/test_channels_ci_fix.py
@@ -26,6 +26,7 @@ async def github_channel():
         github_webhook_port=0,
         github_webhook_secret="test-secret",
         github_token="ghp_fake",
+        github_repo="owner/repo",
     )
     channel = GitHubChannel(task_runner=task_runner, settings=settings)
     yield channel


### PR DESCRIPTION
This PR adds the --repo flag to all gh CLI calls in GitHubChannel to ensure they work correctly even when there is no ambient git remote context.